### PR TITLE
sys/io.hのインポート削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tspacketchk
+*.o

--- a/def.h
+++ b/def.h
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <sys/io.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
ARM64で使用したかったものの、`sys/io.h`が存在しないためビルドできませんでした。
しかし、ソースコードでは使用している形跡がなかったため、削除することでARM64環境のサポートの追加ができると考えています。

なお、適用後にARM64環境で問題なく使用できることを確認しています。
